### PR TITLE
self reference correct package

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,6 +7,6 @@
 # * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
-library(02)
+library(simcuber)
 
-test_check("02")
+test_check("simcuber")


### PR DESCRIPTION
We had some code from the previous repository, causing an R CMD CHECK error, and the tests to not work. By deleting the file and regenerating it, this is now resolved and we can actually tell what tests are failing. 